### PR TITLE
Use AkArrays instead of std::vectors in Sound Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -477,3 +477,20 @@ ASALocalRun/
 .localhistory/
 
 # End of https://www.gitignore.io/api/archives,linux,xcode,macos,windows,visualstudio,premake-gmake
+
+# --------------------------------
+# Custom
+
+# Libraries
+Libraries/**/*.h
+Libraries/**/*.cpp
+
+# Xcode
+plugin.entitlements
+*.xcodeproj/
+*.xcworkspace/
+
+# Custom directories
+ForPackaging/
+PackagedPlugin/
+screencaps/

--- a/SoundEnginePlugin/CircularAudioBuffer/CircularAudioBuffer.h
+++ b/SoundEnginePlugin/CircularAudioBuffer/CircularAudioBuffer.h
@@ -9,8 +9,9 @@
 
 #include <algorithm>
 #include <atomic>
-#include <vector>
 
+#include <AK/SoundEngine/Common/IAkPluginMemAlloc.h> // DS: Add IAkPluginMemAlloc include for AkPluginArrayAllocator 
+#include <AK/Tools/Common/AkArray.h> // DS: Replaced vector include with AkArray include
 
 // Circular audio buffer class.
 template <typename SampleType>
@@ -20,10 +21,11 @@ class CircularAudioBuffer
   // See Section 7.5.1 of Game Audio Programming Vol 3 for full
   // implementation.
 private:
-  std::vector<SampleType> InternalBuffer;
+  AkArray<SampleType, SampleType, AkPluginArrayAllocator> InternalBuffer; // DS: Replaced std::vector<SampleType> with AkArray<SampleType>
   uint32_t Capacity;
   std::atomic<uint32_t> ReadCounter;
   std::atomic<uint32_t> WriteCounter;
+  bool bInitialized; // DS: Added bInitialized to check for array initialization before allocating memory
 
 public:
   CircularAudioBuffer()
@@ -36,19 +38,30 @@ public:
     SetCapacity(InCapacity);
   }
 
+  // DS: Initialize the internal buffer using the memory allocater that is passed in
+  void Init(AK::IAkPluginMemAlloc* InAllocator)
+  {
+    InternalBuffer.Init(InAllocator);
+    bInitialized = true;
+  }
+
   void SetCapacity(uint32_t InCapacity)
   {
     Capacity = InCapacity + 1;
     ReadCounter.store(0);
     WriteCounter.store(0);
-    InternalBuffer.resize(Capacity);
+
+    if (bInitialized)                  // DS: Added initialization check to make sure array is initialized before allocating memory
+    {
+      InternalBuffer.Resize(Capacity); // DS: Replaced resize() with Resize() since we're using an AkArray
+    }
   }
 
   // Pushes some amount of samples into this circular buffer.
   // Returns the amount of samples read
   uint32_t Push(const SampleType* InBuffer, uint32_t NumSamples)
   {
-    SampleType* DestBuffer = InternalBuffer.data();
+    SampleType* DestBuffer = InternalBuffer.Data(); // DS: Replaced data() with Data() since we're using an AkArray
     const uint32_t ReadIndex = ReadCounter.load();
     const uint32_t WriteIndex = WriteCounter.load();
 
@@ -73,7 +86,7 @@ public:
   // Same as Pop() but does not increment the read counter.
   uint32_t Peek(SampleType* OutBuffer, uint32_t NumSamples) const
   {
-    const SampleType* SrcBuffer = static_cast<const SampleType*>(InternalBuffer.data()); // DS: Added const SampleType* cast
+    const SampleType* SrcBuffer = static_cast<const SampleType*>(InternalBuffer.Data()); // DS: Added const SampleType* cast, replaced data() with Data() since we're using an AkArray
     const uint32_t ReadIndex = ReadCounter.load(); // DS: Replaced uint32 with uint32_t
     const uint32_t WriteIndex = WriteCounter.load(); // DS: Replaced uint32 with uint32_t
 
@@ -185,6 +198,12 @@ public:
   void AlignReadWriteIndices()
   {
     SetNum(0, false);
+  }
+
+  // DS: Return whether the buffer has been initialized yet
+  bool IsInitialized()
+  {
+    return bInitialized;
   }
 
 };

--- a/SoundEnginePlugin/GapTunerAnalysis.cpp
+++ b/SoundEnginePlugin/GapTunerAnalysis.cpp
@@ -13,10 +13,10 @@ namespace GapTunerAnalysis
   
   void CalculateAcf(
     const CircularAudioBuffer<float>& InAnalysisWindow,
-    std::vector<float>& OutAutocorrelations)
+      AkArray<float, float, AkPluginArrayAllocator>& OutAutocorrelations)
   {
     assert(
-      InAnalysisWindow.GetCapacity() == OutAutocorrelations.size());
+      InAnalysisWindow.GetCapacity() == OutAutocorrelations.Length());
     
     const size_t WindowSize = InAnalysisWindow.GetCapacity();
 
@@ -65,14 +65,14 @@ namespace GapTunerAnalysis
 
   void CalculateAcf_Fft(
     const CircularAudioBuffer<float>& InAnalysisWindow,
-    std::vector<std::complex<double>>& OutFftInput,
-    std::vector<std::complex<double>>& OutFftOutput,
-    std::vector<float>& OutAutocorrelations)
+    AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& OutFftInput,
+    AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& OutFftOutput,
+    AkArray<float, float, AkPluginArrayAllocator>& OutAutocorrelations)
   {
     // 1. Fill the input array with the contents of the analysis
     //    window, then zero-pad it so that it's twice the window size
     assert(
-      InAnalysisWindow.GetCapacity() == OutAutocorrelations.size());
+      InAnalysisWindow.GetCapacity() == OutAutocorrelations.Length());
 
     const size_t AnalysisWindowSize = InAnalysisWindow.GetCapacity();
 
@@ -137,17 +137,17 @@ namespace GapTunerAnalysis
   }
 
   void CalculateFft(
-    const std::vector<std::complex<double>>& InFftSequence,
-    std::vector<std::complex<double>>& OutFftSequence,
+    const AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& InFftSequence,
+    AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& OutFftSequence,
     const dj::fft_dir InFftDirection)
   {
     dj::fft1d(InFftSequence, OutFftSequence, InFftDirection);
   }
 
   uint32_t FindAcfPeakLag(
-    const std::vector<float>& InAutocorrelations)
+    const AkArray<float, float, AkPluginArrayAllocator>& InAutocorrelations)
   {
-    const size_t WindowSize = InAutocorrelations.size();
+    const size_t WindowSize = InAutocorrelations.Length();
     uint32_t PeakLag = 0;
     float PeakCorr = 0.f;
     bool bReachedFirstZeroCrossing = false;
@@ -177,12 +177,12 @@ namespace GapTunerAnalysis
     return PeakLag;
   }
 
-  uint32_t FindKeyMaxima(std::vector<float>& OutKeyMaximaLags,
-                         std::vector<float>& OutKeyMaximaCorrelations,
-                         const std::vector<float>& InAutocorrelations,
+  uint32_t FindKeyMaxima(AkArray<float, float, AkPluginArrayAllocator>& OutKeyMaximaLags,
+                         AkArray<float, float, AkPluginArrayAllocator>& OutKeyMaximaCorrelations,
+                         const AkArray<float, float, AkPluginArrayAllocator>& InAutocorrelations,
                          const uint32_t InMaxNumMaxima)
   {
-    const size_t WindowSize = InAutocorrelations.size();
+    const size_t WindowSize = InAutocorrelations.Length();
     uint32_t MaximaIdx = 0;
     float MaximaLag = 0.f;
     float MaximaCorr = 0.f;
@@ -246,8 +246,8 @@ namespace GapTunerAnalysis
 
   // Pick the best maxima from key maxima
   uint32_t PickBestMaxima(
-    const std::vector<float>& InKeyMaximaLags,
-    const std::vector<float>& InKeyMaximaCorrelations,
+    const AkArray<float, float, AkPluginArrayAllocator>& InKeyMaximaLags,
+    const AkArray<float, float, AkPluginArrayAllocator>& InKeyMaximaCorrelations,
     const uint32_t InNumKeyMaxima,
     const float InThresholdMultiplier)
   {
@@ -291,9 +291,9 @@ namespace GapTunerAnalysis
 
   float FindInterpolatedMaximaLag(
     const uint32_t InMaximaLag,
-    const std::vector<float>& InAutocorrelations)
+    const AkArray<float, float, AkPluginArrayAllocator>& InAutocorrelations)
   {
-    const size_t WindowSize = InAutocorrelations.size();
+    const size_t WindowSize = InAutocorrelations.Length();
     auto InterpolatedLag = static_cast<float>(InMaximaLag);
 
     // Can't interpolate first or last lag value
@@ -351,6 +351,11 @@ namespace GapTunerAnalysis
     const uint32_t NumChannels = InBuffer->NumChannels();
     const uint32_t NumSamples = InBuffer->uValidFrames;
     uint32_t NumSamplesPushed = 0;
+
+    if (!InOutWindow.IsInitialized())
+    {
+      return NumSamplesPushed;
+    }
 
     // Set analysis window read index to write index, so that we
     // always write as many samples as we have available

--- a/SoundEnginePlugin/GapTunerAnalysis.h
+++ b/SoundEnginePlugin/GapTunerAnalysis.h
@@ -12,10 +12,10 @@
 // STL
 #include <algorithm>
 #include <complex>
-#include <vector>
 
 // AK
 #include <AK/SoundEngine/Common/IAkPlugin.h>
+#include <AK/Tools/Common/AkArray.h>
 
 // CircularAudioBuffer
 #include "CircularAudioBuffer/CircularAudioBuffer.h"
@@ -31,7 +31,7 @@ namespace GapTunerAnalysis
   // Calculate normalized autocorrelation function for a window
   void CalculateAcf(
     const CircularAudioBuffer<float>& InAnalysisWindow,
-    std::vector<float>& OutAutocorrelations);
+    AkArray<float, float, AkPluginArrayAllocator>& OutAutocorrelations);
 
   // Calculate autocorrelation (using dot product) for a given lag
   float CalculateAcfForLag(
@@ -44,15 +44,15 @@ namespace GapTunerAnalysis
   // Calculate autocorrelation using the FFT
   void CalculateAcf_Fft(
     const CircularAudioBuffer<float>& InAnalysisWindow,
-    std::vector<std::complex<double>>& OutFftInput,
-    std::vector<std::complex<double>>& OutFftOutput,
-    std::vector<float>& OutAutocorrelations);
+    AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& OutFftInput,
+    AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& OutFftOutput,
+    AkArray<float, float, AkPluginArrayAllocator>& OutAutocorrelations);
 
   // Calculate the FFT (forwards or backwards) given an input
   // sequence
   void CalculateFft(
-    const std::vector<std::complex<double>>& InFftSequence,
-    std::vector<std::complex<double>>& OutFftSequence,
+    const AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& InFftSequence,
+    AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator>& OutFftSequence,
     const dj::fft_dir InFftDirection);
 
   // ----------------
@@ -61,28 +61,28 @@ namespace GapTunerAnalysis
   // Pick the peak lag given the autocorrelation coefficients for a
   // series of time lags
   uint32_t FindAcfPeakLag(
-    const std::vector<float>& InAutocorrelations);
+    const AkArray<float, float, AkPluginArrayAllocator>& InAutocorrelations);
 
   // ----------------
   // Peak-picking -- MPM
 
   // Gather a list of key maxima using the MPM's peak-picking process
-  uint32_t FindKeyMaxima(std::vector<float>& OutKeyMaximaLags,
-                         std::vector<float>& OutKeyMaximaCorrelations,
-                         const std::vector<float>& InAutocorrelations,
+  uint32_t FindKeyMaxima(AkArray<float, float, AkPluginArrayAllocator>& OutKeyMaximaLags,
+                         AkArray<float, float, AkPluginArrayAllocator>& OutKeyMaximaCorrelations,
+                         const AkArray<float, float, AkPluginArrayAllocator>& InAutocorrelations,
                          const uint32_t InMaxNumMaxima);
 
   // Pick the best maxima from a list of key maxima
   uint32_t PickBestMaxima(
-    const std::vector<float>& InKeyMaximaLags,
-    const std::vector<float>& InKeyMaximaCorrelations,
+    const AkArray<float, float, AkPluginArrayAllocator>& InKeyMaximaLags,
+    const AkArray<float, float, AkPluginArrayAllocator>& InKeyMaximaCorrelations,
     const uint32_t InNumKeyMaxima,
     const float InThresholdMultiplier);
 
   // Find the interpolated maxima for a given lag
   float FindInterpolatedMaximaLag(
     const uint32_t InMaximaLag,
-    const std::vector<float>& InAutocorrelations);
+    const AkArray<float, float, AkPluginArrayAllocator>& InAutocorrelations);
 
   // ----------------
   // Utilities

--- a/SoundEnginePlugin/GapTunerFX.cpp
+++ b/SoundEnginePlugin/GapTunerFX.cpp
@@ -60,12 +60,14 @@ AKRESULT GapTunerFX::Init(AK::IAkPluginMemAlloc* InAllocator,
   // Allocate memory for analysis window
   const uint32_t WindowSize = GetWindowSize();
 
-  m_AutocorrelationCoefficients.resize(WindowSize);
+  m_AutocorrelationCoefficients.Init(m_PluginMemoryAllocator);
+  m_AutocorrelationCoefficients.Resize(WindowSize);
 
   // The circular buffer sets its internal capacity to
   // InCapacity + 1; if we pass in WindowSize - 1, then
   // m_AnalysisWindow.GetCapacity() == WindowSize, which is
   // the result we want
+  m_AnalysisWindow.Init(m_PluginMemoryAllocator);
   m_AnalysisWindow.SetCapacity(WindowSize - 1); 
 
   // ----
@@ -73,15 +75,21 @@ AKRESULT GapTunerFX::Init(AK::IAkPluginMemAlloc* InAllocator,
   const uint32_t MaxNumKeyMaxima =
     m_PluginParams->NonRTPC.MaxNumKeyMaxima;
 
-  m_KeyMaximaLags.resize(MaxNumKeyMaxima);
-  m_KeyMaximaCorrelations.resize(MaxNumKeyMaxima);
+  m_KeyMaximaLags.Init(m_PluginMemoryAllocator);
+  m_KeyMaximaLags.Resize(MaxNumKeyMaxima);
+
+  m_KeyMaximaCorrelations.Init(m_PluginMemoryAllocator);
+  m_KeyMaximaCorrelations.Resize(MaxNumKeyMaxima);
 
   // ----
   // Allocate memory for FFT
   const uint32_t FftWindowSize = WindowSize * 2;
 
-  m_FftIn.resize(FftWindowSize);
-  m_FftOut.resize(FftWindowSize);
+  m_FftIn.Init(m_PluginMemoryAllocator);
+  m_FftIn.Resize(FftWindowSize);
+
+  m_FftOut.Init(m_PluginMemoryAllocator);
+  m_FftOut.Resize(FftWindowSize);
 
   // ----
   // Reset cooldown book-keeping

--- a/SoundEnginePlugin/GapTunerFX.h
+++ b/SoundEnginePlugin/GapTunerFX.h
@@ -37,6 +37,7 @@ the specific language governing permissions and limitations under the License.
 
 // AK
 #include <AK/SoundEngine/Common/IAkPlugin.h>
+#include <AK/Tools/Common/AkArray.h>
 
 // CircularAudioBuffer
 #include "CircularAudioBuffer/CircularAudioBuffer.h"
@@ -125,13 +126,13 @@ private:
   uint32_t m_AnalysisWindowSamplesWritten { 0 };
 
   // Calculated autocorrelation coefficients
-  std::vector<float> m_AutocorrelationCoefficients { };
+  AkArray<float, float, AkPluginArrayAllocator> m_AutocorrelationCoefficients { };
 
   // Key maxima lags and correlations, for MPM-based peak-picking
-  std::vector<float> m_KeyMaximaLags { };
-  std::vector<float> m_KeyMaximaCorrelations { };
+  AkArray<float, float, AkPluginArrayAllocator> m_KeyMaximaLags { };
+  AkArray<float, float, AkPluginArrayAllocator> m_KeyMaximaCorrelations { };
 
   // FFT
-  std::vector<std::complex<double>> m_FftIn { };
-  std::vector<std::complex<double>> m_FftOut { };
+  AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator> m_FftIn { };
+  AkArray<std::complex<double>, std::complex<double>, AkPluginArrayAllocator> m_FftOut { };
 };

--- a/SoundEnginePlugin/dj_fft/dj_fft.cpp
+++ b/SoundEnginePlugin/dj_fft/dj_fft.cpp
@@ -91,12 +91,13 @@ template <typename T> fft_arg<T> fft1d(const fft_arg<T> &xi, const fft_dir &dir)
 }
 
 /*
+ * DS:
  * Overloaded version of fft1d() that uses raw arrays instead of vectors.
  *
  * This version of the function also takes in xo and modifies it directly,
  * instead of allocating additional memory for a return array.
  */
-template<typename T> void fft1d(fft_arg_raw<T>& xi, fft_arg_raw<T>& xo, const fft_dir& dir, const uint32_t& sz)
+template <typename T> void fft1d(fft_arg_raw<T>& xi, fft_arg_raw<T>& xo, const fft_dir& dir, const uint32_t& sz)
 {
     DJ_ASSERT((sz & (sz - 1)) == 0 && "invalid input size");
     int cnt = (int)sz;

--- a/SoundEnginePlugin/dj_fft/dj_fft.h
+++ b/SoundEnginePlugin/dj_fft/dj_fft.h
@@ -15,6 +15,9 @@ by Jonathan Dupuy
 #include <complex>  // std::complex
 #include <vector>   // std::vector
 
+#include <AK/SoundEngine/Common/IAkPluginMemAlloc.h> // AkPluginArrayAllocator
+#include <AK/Tools/Common/AkArray.h> // AkArray
+
 #ifndef DJ_ASSERT
 #   include <cassert>
 #   define DJ_ASSERT(x) assert(x)
@@ -43,6 +46,7 @@ fft_arg<float> fft1d_gpu_glready(const fft_arg<float> &xi, const fft_dir &dir);
 fft_arg<float> fft2d_gpu_glready(const fft_arg<float> &xi, const fft_dir &dir);
 fft_arg<float> fft3d_gpu_glready(const fft_arg<float> &xi, const fft_dir &dir);
 
+// DS:
 // Raw array FFT routines
 template <typename T> using fft_arg_raw = std::complex<T>*;
 template<typename T> void fft1d(fft_arg_raw<T>& xi,
@@ -53,6 +57,7 @@ template<typename T> void fft1d(fft_arg_raw<T>& xi,
 
 // ----------------------------------------------------------------
 
+// DS:
 // Overloaded version of fft1d() that takes in both an input vector
 // (xi) and an output vector (xo), modifying the output vector
 // directly instead of allocating additional memory for a return
@@ -84,6 +89,49 @@ template <typename T> void fft1d(const fft_arg<T>& xi,
               std::polar(T(1), ang * T(i1 ^ bw)); // left wing rotation
             std::complex<T> z2 =
               std::polar(T(1), ang * T(i2 ^ bw)); // right wing rotation
+            std::complex<T> tmp = xo[i1];
+
+            xo[i1] += z1 * xo[i2];
+            xo[i2] = tmp + z2 * xo[i2];
+        }
+    }
+}
+
+// ----------------------------------------------------------------
+
+// DS:
+// Overloaded version of fft1d() that takes in both an input AkArray
+// (xi) and an output AkArray (xo), modifying the output AkArray
+// directly instead of allocating additional memory for a return
+// AkArray.
+template <typename T> void fft1d(
+    const AkArray<std::complex<T>, std::complex<T>, AkPluginArrayAllocator>& xi,
+    AkArray<std::complex<T>, std::complex<T>, AkPluginArrayAllocator>& xo,
+    const fft_dir& dir)
+{
+    DJ_ASSERT((xi.Length() & (xi.Length() - 1)) == 0 && "invalid input size");
+    int cnt = (int)xi.Length();
+    int msb = findMSB(cnt);
+    T nrm = T(1) / std::sqrt(T(cnt));
+
+    // pre-process the input data
+    for (int j = 0; j < cnt; ++j)
+        xo[j] = nrm * xi[bitr(j, msb)];
+
+    // fft passes
+    for (int i = 0; i < msb; ++i) {
+        int bm = 1 << i; // butterfly mask
+        int bw = 2 << i; // butterfly width
+        T ang = T(dir) * M_PI / T(bm); // precomputation
+
+        // fft butterflies
+        for (int j = 0; j < (cnt / 2); ++j) {
+            int i1 = ((j >> i) << (i + 1)) + j % bm; // left wing
+            int i2 = i1 ^ bm;                        // right wing
+            std::complex<T> z1 =
+                std::polar(T(1), ang * T(i1 ^ bw)); // left wing rotation
+            std::complex<T> z2 =
+                std::polar(T(1), ang * T(i2 ^ bw)); // right wing rotation
             std::complex<T> tmp = xo[i1];
 
             xo[i1] += z1 * xo[i2];

--- a/SoundEnginePlugin/dj_fft/dj_fft.h
+++ b/SoundEnginePlugin/dj_fft/dj_fft.h
@@ -15,8 +15,8 @@ by Jonathan Dupuy
 #include <complex>  // std::complex
 #include <vector>   // std::vector
 
-#include <AK/SoundEngine/Common/IAkPluginMemAlloc.h> // AkPluginArrayAllocator
-#include <AK/Tools/Common/AkArray.h> // AkArray
+#include <AK/SoundEngine/Common/IAkPluginMemAlloc.h>  // AkPluginArrayAllocator
+#include <AK/Tools/Common/AkArray.h>                  // AkArray
 
 #ifndef DJ_ASSERT
 #   include <cassert>
@@ -54,6 +54,9 @@ template<typename T> void fft1d(fft_arg_raw<T>& xi,
                                 const fft_dir& dir,
                                 const uint32_t& sz);
 
+// DS:
+// AkArray FFT argument: AkArray<std::complex, std::complex, AkPluginArrayAllocator>
+template <typename T> using fft_arg_ak = AkArray<std::complex<T>, std::complex<T>, AkPluginArrayAllocator>;
 
 // ----------------------------------------------------------------
 
@@ -100,14 +103,11 @@ template <typename T> void fft1d(const fft_arg<T>& xi,
 // ----------------------------------------------------------------
 
 // DS:
-// Overloaded version of fft1d() that takes in both an input AkArray
-// (xi) and an output AkArray (xo), modifying the output AkArray
-// directly instead of allocating additional memory for a return
-// AkArray.
-template <typename T> void fft1d(
-    const AkArray<std::complex<T>, std::complex<T>, AkPluginArrayAllocator>& xi,
-    AkArray<std::complex<T>, std::complex<T>, AkPluginArrayAllocator>& xo,
-    const fft_dir& dir)
+// Overloaded version of fft1d() that uses AkArrays instead of
+// vectors.
+template <typename T> void fft1d(const fft_arg_ak<T>& xi,
+                                 fft_arg_ak<T>& xo,
+                                 const fft_dir& dir)
 {
     DJ_ASSERT((xi.Length() & (xi.Length() - 1)) == 0 && "invalid input size");
     int cnt = (int)xi.Length();


### PR DESCRIPTION
This allows us to use the memory allocator received from the host during plugin initialization.